### PR TITLE
We should add optional children here

### DIFF
--- a/src/CodeItem.re
+++ b/src/CodeItem.re
@@ -791,7 +791,10 @@ let codeItemsForMake = (~config, ~moduleName, ~valueBinding, id) => {
     let propsTypeArguments =
       switch (childrenOrNil) {
       /* Then we only extracted a function that accepts children, no props */
-      | [] => ObjectType([])
+      | [] =>
+        /* Add children?:any to props type */
+        let childrenField = ("children", NonMandatory, EmitTyp.any);
+        ObjectType([childrenField]);
       /* Then we had both props and children. */
       | [_children, ..._] =>
         switch (propOrChildren) {


### PR DESCRIPTION
If not

```
[@genFlow]
let make = (children) => {
  ...component,
  render: _self => <Text style=Styles.largeTitle> ...children </Text>,
};
```
would make flow complain when passing children from JS, because outputted flow props doesn't have optional children.

This only happens when `children` is the only prop.