### PR TITLE
Bring back setProjectRoot reference to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There are some steps to set up `genFlow` in a project.
 Some of this might become simpler if `genFlow` gets integrated
 into bucklescript in future. The current requirement is `bs-platform 4.0.3` or later.
 
-1. Set environment variable with `export BS_CMT_POST_PROCESS_CMD="$GENFLOW_REPO/lib/bs/native/genflow.native`, before building a project, or starting a watcher / vscode with bsb integration.
+1. Set environment variable with `export BS_CMT_POST_PROCESS_CMD="$GENFLOW_REPO/lib/bs/native/genflow.native --setProjectRoot $PWD`, before building a project, or starting a watcher / vscode with bsb integration.
 2. Add a file [`genflowconfig.json`](examples/reason-react-example/genflowconfig.json) in the project root, and relevant `.shims.js` files in a directory which is visible by bucklescript e.g. [`src/shims/`](examples/reason-react-example/src/shims). An example for a ReasonReact->React shim can be found [here](examples/reason-react-example/src/shims/ReactShim.shim.js).
 3. Open your relevant `*.re` file and add `[@genType]` annotations to any bindings / values / functions to be used from javascript. If an annotated value uses a type, the type must be annotated too. See e.g. [Component1.re](examples/reason-react-example/src/basics/Component1.re).
 4. If using webpack and Flow, set up [extension-replace-loader](https://www.npmjs.com/package/extension-replace-loader) so webpack will pick up the appropriate `Foo.re.js` instead of `Foo.re`  [example webpack.config.js](examples/reason-react-example/webpack.config.js).


### PR DESCRIPTION
Hopefully helps other people that are also wondering why `export BS_CMT_POST_PROCESS_CMD="$GENFLOW_REPO/lib/bs/native/genflow.native` isn't working.

@cristianoc I think a newcomer could probably give up, as there is no feedback from genFlow when `setProjectRoot` is missing. Should it show an error if that's the case?